### PR TITLE
Pipeline review

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -83,16 +83,20 @@ node {
             ],
         ],
     ]])
-    stage('Merge and build') {
-        try_wrapper(mail_failure) {
+    try_wrapper(mail_failure) {
+        stage('dependencies') {
             env.GOPATH = env.WORKSPACE + '/go'
             dir(env.GOPATH) { deleteDir() }
             sh 'go get github.com/jteeuwen/go-bindata'
+        }
+        stage('web console') {
             dir(env.GOPATH + '/src/github.com/openshift/origin-web-console') {
                 git url: WEB_CONSOLE_REPO
                 def v = "enterprise-${OSE_MAJOR}.${OSE_MINOR}"
                 git_merge('master', "origin/${v}", "Merge master into ${v}")
             }
+        }
+        stage('merge') {
             dir(env.GOPATH + '/src/github.com/openshift/ose') {
                 checkout(
                     $class: 'GitSCM',

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -106,15 +106,7 @@ node {
                     'master', 'upstream/master',
                     'Merge remote-tracking branch upstream/master',
                     '--strategy-option=theirs')
-                def web_console_ref = sh(
-                    returnStdout: true,
-                    script: "set -o pipefail && GIT_REF=master hack/vendor-console.sh | awk '/Vendoring origin-web-console/{print \$4}'")
-                if(sh(
-                        script: 'git status --porcelain',
-                        returnStdout: true)) {
-                    sh 'git add pkg/assets/{,java/}bindata.go'
-                    sh "git commit -m 'Merge remote-tracking branch upstream/master, bump origin-web-console ${web_console_ref}'"
-                }
+                sh 'GIT_REF=master COMMIT=1 hack/vendor-console.sh'
                 sh 'tito tag --accept-auto-changelog'
                 def v = readFile(file: 'origin.spec') =~ /Version:\s+([.0-9]+)/
                 mail_success(v[0][1])

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,3 +1,42 @@
+// TODO Replace flow control (when available) with:
+// https://jenkins.io/blog/2016/12/19/declarative-pipeline-beta/
+def try_wrapper(failure_func, f) {
+    try {
+        f.call()
+    } catch(err) {
+        failure_func(err)
+        // Re-throw the error in order to fail the job
+        throw err
+    }
+}
+
+def mail_success(version) {
+    mail(
+        to: 'jupierce@redhat.com',
+        subject: "[aos-devel] New AtomicOpenShift Puddle for OSE: ${version}",
+        body: """\
+v${version}
+Images have been built for this puddle
+Images have been pushed to registry.ops
+Puddles have been synched to mirrors
+
+
+Jenkins job: ${env.BUILD_URL}
+""");
+}
+
+def mail_failure = { err ->
+    mail(
+        to: 'jupierce@redhat.com',
+        subject: "Error building OSE: ${OSE_MAJOR}.${OSE_MINOR}",
+        body: """\
+Encoutered an error while running merge-and-build.sh: ${err}
+
+
+Jenkins job: ${env.BUILD_URL}
+""");
+}
+
 node {
     properties([[
         $class: 'ParametersDefinitionProperty',
@@ -35,9 +74,8 @@ node {
             ],
         ],
     ]])
-
     stage('Merge and build') {
-        try {
+        try_wrapper(mail_failure) {
             env.GOPATH = env.WORKSPACE + '/go'
             dir(env.GOPATH) { deleteDir() }
             sh 'go get github.com/jteeuwen/go-bindata'
@@ -68,35 +106,9 @@ node {
                     sh "git commit -m 'Merge remote-tracking branch upstream/master, bump origin-web-console ${web_console_ref}'"
                 }
                 sh 'tito tag --accept-auto-changelog'
-                def specVersion = readFile( file: 'origin.spec' ).find( /Version: ([.0-9]+)/) {
-                    full, ver -> return ver;
-                }
-                // Replace flow control with: https://jenkins.io/blog/2016/12/19/declarative-pipeline-beta/ when available
-                mail(to: "jupierce@redhat.com",
-                        subject: "[aos-devel] New AtomicOpenShift Puddle for OSE: ${specVersion}",
-                        body: """v${specVersion}
-Images have been built for this puddle
-Images have been pushed to registry.ops
-Puddles have been synched to mirrors
-
-
-Jenkins job: ${env.BUILD_URL}
-""");
+                def v = readFile(file: 'origin.spec') =~ /Version:\s+([.0-9]+)/
+                mail_success(v[0][1])
             }
-
-
-        } catch ( err ) {
-            // Replace flow control with: https://jenkins.io/blog/2016/12/19/declarative-pipeline-beta/ when available
-            mail(to: "jupierce@redhat.com",
-                    subject: "Error building OSE: ${OSE_MAJOR}.${OSE_MINOR}",
-                    body: """Encoutered an error while running merge-and-build.sh: ${err}
-
-
-Jenkins job: ${env.BUILD_URL}
-""");
-            // Re-throw the error in order to fail the job
-            throw err
         }
-
     }
 }


### PR DESCRIPTION
Follow-up for the review done in #1.  Addressed all the comments referring to
the code structure, the pipeline code is much clearer now.

The build currently takes ~100s, ~90s of which are spent cloning the `ose`
repository.  We can potentially speed it up by retaining the repository between
builds.  I'm leaving it as "good enough" for now, the next steps will probably
take much longer.