### PR TITLE
Use buildvm

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -46,7 +46,7 @@ git merge ${merge_opts} '${commit}' -m '${commit_msg}'
 """)
 }
 
-node {
+node('buildvm-devops') {
     properties([[
         $class: 'ParametersDefinitionProperty',
         parameterDefinitions: [


### PR DESCRIPTION
I forgot a small detail ;)

I was also looking at the selinux issue this morning.  I could not find a way
to change how the docker plugin generates the list of mounts:

https://github.com/jenkinsci/docker-workflow-plugin/blob/master/src/main/java/org/jenkinsci/plugins/docker/workflow/WithContainerStep.java#L150

but I believe we can avoid having to use the `--privileged` flag by changing
the selinux label on the workspace directory in buildvm:

```
chcon -Rt svirt_sandbox_file_t \
    ~jenkins/workspace/aos-cd-builds/build%2Fose-pipeline{,@tmp}
```

This is essentially what we do in docker to allow the container to write to the
directory (and so when/if docker is updated on the node, we shouldn't need to
change anything):

http://www.projectatomic.io/blog/2015/06/using-volumes-with-docker-can-cause-problems-with-selinux/
